### PR TITLE
fix: remove operator and userdata from Transfer event

### DIFF
--- a/ERC821.md
+++ b/ERC821.md
@@ -25,7 +25,7 @@ The number of virtual collectibles tracked on the Ethereum blockchain is rapidly
 
 See also: ERC #721, ERC #20, ERC #223, and ERC #777.
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
 
 ## Specification
 
@@ -135,7 +135,7 @@ Transfers holding of the NFT referenced by `assetId` from `ownerOf(assetId)` to 
 
 `to` SHALL NOT be `ownerOf(assetId)`. If this condition is met, the call MUST throw.
 
-`isAuthorizedBy(msg.sender, ownerOf(assetId))` MUST return true as a precondition. 
+`isAuthorizedBy(msg.sender, ownerOf(assetId))` MUST return true as a precondition.
 
 This means that the `msg.sender` MUST be `ownerOf(assetId)` or an authorized operator.
 
@@ -154,6 +154,7 @@ If the call doesn't throw, it triggers the event `Transfer` with the following p
 
 If `to` is a contract's address, this call MUST verify that the contract can receive the tokens. In order to do so, the method MUST do a #165 check for support to handle tokens to the target contract.
 The implementation for the receiver is as follows:
+
 ```
 interface IAssetHolder {
   function onAssetReceived(
@@ -220,9 +221,7 @@ interface AssetRegistryEvents {
     address indexed from,
     address indexed to,
     uint256 indexed assetId,
-    address operator,
-    bytes userData,
-    bytes operatorData
+    address operator
   );
   event AuthorizeOperator(
     address indexed operator,
@@ -236,7 +235,9 @@ interface AssetRegistryEvents {
   );
 }
 ```
+
 ### Interfaces
+
 ```
 interface IAssetRegistry {
   function totalSupply() public view returns (uint256);
@@ -300,4 +301,3 @@ https://github.com/decentraland/erc821
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
-

--- a/ERC821.md
+++ b/ERC821.md
@@ -220,8 +220,7 @@ interface AssetRegistryEvents {
   event Transfer(
     address indexed from,
     address indexed to,
-    uint256 indexed assetId,
-    address operator
+    uint256 indexed assetId
   );
   event AuthorizeOperator(
     address indexed operator,

--- a/ERC821.md
+++ b/ERC821.md
@@ -148,9 +148,6 @@ If the call doesn't throw, it triggers the event `Transfer` with the following p
 * from: value of `ownerOf(assetId)` before the call
 * to: the `to` argument
 * assetId: the `assetId` argument
-* operator: `msg.sender`
-* userData: the `userData` argument
-* operatorData: the `operatorData` argument
 
 If `to` is a contract's address, this call MUST verify that the contract can receive the tokens. In order to do so, the method MUST do a #165 check for support to handle tokens to the target contract.
 The implementation for the receiver is as follows:
@@ -222,6 +219,13 @@ interface AssetRegistryEvents {
     address indexed to,
     uint256 indexed assetId
   );
+  event Transfer(
+    address indexed from,
+    address indexed to,
+    uint256 indexed assetId,
+    address operator,
+    bytes userData
+  );
   event AuthorizeOperator(
     address indexed operator,
     address indexed holder,
@@ -272,6 +276,7 @@ https://github.com/decentraland/erc821
 
 ## Revisions
 
+* 2018/08/22: Make Transfer() event compliant with the ERC721 reference implementation
 * 2018/02/21: RC2, drop name, symbol, description
 * 2018/02/21: RC1
 * 2018/02/20: Drop metadata

--- a/contracts/ERC721Base.sol
+++ b/contracts/ERC721Base.sol
@@ -220,7 +220,7 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
 
     _addAssetTo(beneficiary, assetId);
 
-    emit Transfer(0, beneficiary, assetId, msg.sender);
+    emit Transfer(0, beneficiary, assetId);
   }
 
   function _destroy(uint256 assetId) internal {
@@ -229,7 +229,7 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
 
     _removeAssetFrom(holder, assetId);
 
-    emit Transfer(holder, 0, assetId, msg.sender);
+    emit Transfer(holder, 0, assetId);
   }
 
   //
@@ -269,7 +269,7 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
    * @param assetId uint256 ID of the asset to be transferred
    */
   function safeTransferFrom(address from, address to, uint256 assetId) external {
-    return _doTransferFrom(from, to, assetId, '', msg.sender, true);
+    return _doTransferFrom(from, to, assetId, '', true);
   }
 
   /**
@@ -283,7 +283,7 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
    * @param userData bytes arbitrary user information to attach to this transfer
    */
   function safeTransferFrom(address from, address to, uint256 assetId, bytes userData) external {
-    return _doTransferFrom(from, to, assetId, userData, msg.sender, true);
+    return _doTransferFrom(from, to, assetId, userData, true);
   }
 
   /**
@@ -296,7 +296,7 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
    * @param assetId uint256 ID of the asset to be transferred
    */
   function transferFrom(address from, address to, uint256 assetId) external {
-    return _doTransferFrom(from, to, assetId, '', msg.sender, false);
+    return _doTransferFrom(from, to, assetId, "", false);
   }
 
   function _doTransferFrom(
@@ -304,13 +304,12 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
     address to,
     uint256 assetId,
     bytes userData,
-    address operator,
     bool doCheck
   )
     onlyAuthorized(assetId)
     internal
   {
-    _moveToken(from, to, assetId, userData, operator, doCheck);
+    _moveToken(from, to, assetId, userData, doCheck);
   }
 
   function _moveToken(
@@ -318,7 +317,6 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
     address to,
     uint256 assetId,
     bytes userData,
-    address operator,
     bool doCheck
   )
     isDestinataryDefined(to)
@@ -341,7 +339,7 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
       );
     }
 
-    emit Transfer(holder, to, assetId, operator);
+    emit Transfer(holder, to, assetId);
   }
 
   /**

--- a/contracts/ERC721Base.sol
+++ b/contracts/ERC721Base.sol
@@ -220,7 +220,7 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
 
     _addAssetTo(beneficiary, assetId);
 
-    emit Transfer(0, beneficiary, assetId, msg.sender, '');
+    emit Transfer(0, beneficiary, assetId, msg.sender);
   }
 
   function _destroy(uint256 assetId) internal {
@@ -229,7 +229,7 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
 
     _removeAssetFrom(holder, assetId);
 
-    emit Transfer(holder, 0, assetId, msg.sender, '');
+    emit Transfer(holder, 0, assetId, msg.sender);
   }
 
   //
@@ -341,7 +341,7 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
       );
     }
 
-    emit Transfer(holder, to, assetId, operator, userData);
+    emit Transfer(holder, to, assetId, operator);
   }
 
   /**

--- a/contracts/ERC721Base.sol
+++ b/contracts/ERC721Base.sol
@@ -296,7 +296,7 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
    * @param assetId uint256 ID of the asset to be transferred
    */
   function transferFrom(address from, address to, uint256 assetId) external {
-    return _doTransferFrom(from, to, assetId, "", false);
+    return _doTransferFrom(from, to, assetId, '', false);
   }
 
   function _doTransferFrom(

--- a/contracts/IERC721Base.sol
+++ b/contracts/IERC721Base.sol
@@ -21,11 +21,21 @@ interface IERC721Base {
 
   function isAuthorized(address operator, uint256 assetId) external view returns (bool);
 
+  /**
+   * @dev Deprecated transfer event. Now we use the standard with three parameters
+   * It is only used in the ABI to get old transfer events. Do not remove
+   */
   event Transfer(
     address indexed from,
     address indexed to,
     uint256 indexed assetId,
-    address operator
+    address operator,
+    bytes userData
+  );
+  event Transfer(
+    address indexed from,
+    address indexed to,
+    uint256 indexed assetId
   );
   event ApprovalForAll(
     address indexed operator,

--- a/contracts/IERC721Base.sol
+++ b/contracts/IERC721Base.sol
@@ -25,8 +25,7 @@ interface IERC721Base {
     address indexed from,
     address indexed to,
     uint256 indexed assetId,
-    address operator,
-    bytes userData
+    address operator
   );
   event ApprovalForAll(
     address indexed operator,

--- a/test/Exchange.sol
+++ b/test/Exchange.sol
@@ -8,7 +8,7 @@ contract Exchange {
 
   StandardAssetRegistryTest internal nonFungible;
 
-  function Exchange (address _nonFungible) public {
+  constructor(address _nonFungible) public {
     nonFungible = StandardAssetRegistryTest(_nonFungible);
   }
 

--- a/test/StandardAssetRegistry.js
+++ b/test/StandardAssetRegistry.js
@@ -8,12 +8,11 @@ const NonHolder = artifacts.require('NonHolder')
 
 const NONE = '0x0000000000000000000000000000000000000000'
 
-function checkTransferLog(log, assetId, from, to, operator) {
+function checkTransferLog(log, assetId, from, to) {
   log.event.should.be.eq('Transfer')
   log.args.assetId.should.be.bignumber.equal(assetId)
   log.args.from.should.be.equal(from)
   log.args.to.should.be.equal(to)
-  log.args.operator.should.be.equal(operator)
 }
 
 function checkAuthorizationLog(log, operator, holder, authorized) {
@@ -35,7 +34,6 @@ function checkCreateLog(log, holder, assetId, operator) {
   log.args.from.should.be.equal(NONE)
   log.args.to.should.be.equal(holder)
   log.args.assetId.should.be.bignumber.equal(assetId)
-  log.args.operator.should.be.equal(operator)
 }
 
 function checkDestroyLog(log, holder, assetId, operator) {
@@ -43,7 +41,6 @@ function checkDestroyLog(log, holder, assetId, operator) {
   log.args.from.should.be.equal(holder)
   log.args.to.should.be.equal(NONE)
   log.args.assetId.should.be.bignumber.equal(assetId)
-  log.args.operator.should.be.equal(operator)
 }
 
 require('chai')
@@ -287,13 +284,7 @@ contract('StandardAssetRegistry', accounts => {
         USER_DATA,
         { from: creator }
       )
-      checkTransferLog(
-        logs[0],
-        asset,
-        creator,
-        holder.address,
-        creator
-      )
+      checkTransferLog(logs[0], asset, creator, holder.address)
     })
 
     it('non holder does not receive the token', async () => {

--- a/test/StandardAssetRegistry.js
+++ b/test/StandardAssetRegistry.js
@@ -8,13 +8,12 @@ const NonHolder = artifacts.require('NonHolder')
 
 const NONE = '0x0000000000000000000000000000000000000000'
 
-function checkTransferLog(log, assetId, from, to, operator, userData) {
+function checkTransferLog(log, assetId, from, to, operator) {
   log.event.should.be.eq('Transfer')
   log.args.assetId.should.be.bignumber.equal(assetId)
   log.args.from.should.be.equal(from)
   log.args.to.should.be.equal(to)
   log.args.operator.should.be.equal(operator)
-  log.args.userData.should.be.equal(userData)
 }
 
 function checkAuthorizationLog(log, operator, holder, authorized) {
@@ -293,8 +292,7 @@ contract('StandardAssetRegistry', accounts => {
         asset,
         creator,
         holder.address,
-        creator,
-        '0x' + Buffer.from(USER_DATA).toString('hex')
+        creator
       )
     })
 

--- a/test/StandardAssetRegistry.js
+++ b/test/StandardAssetRegistry.js
@@ -1,5 +1,5 @@
 import assertRevert from './helpers/assertRevert'
-import { assertError } from './helpers/assertRevert'
+
 const BigNumber = web3.BigNumber
 
 const StandardAssetRegistry = artifacts.require('StandardAssetRegistryTest')
@@ -29,14 +29,14 @@ function checkApproveLog(log, owner, operator, assetId) {
   log.args.assetId.should.be.bignumber.equal(assetId)
 }
 
-function checkCreateLog(log, holder, assetId, operator) {
+function checkCreateLog(log, holder, assetId) {
   log.event.should.be.eq('Transfer')
   log.args.from.should.be.equal(NONE)
   log.args.to.should.be.equal(holder)
   log.args.assetId.should.be.bignumber.equal(assetId)
 }
 
-function checkDestroyLog(log, holder, assetId, operator) {
+function checkDestroyLog(log, holder, assetId) {
   log.event.should.be.eq('Transfer')
   log.args.from.should.be.equal(holder)
   log.args.to.should.be.equal(NONE)

--- a/test/StandardAssetRegistryTest.sol
+++ b/test/StandardAssetRegistryTest.sol
@@ -4,7 +4,7 @@ import '../contracts/FullAssetRegistry.sol';
 
 contract StandardAssetRegistryTest is FullAssetRegistry {
 
-  function StandardAssetRegistryTest () public {
+  constructor() public {
     _name = "Test";
     _symbol = "TEST";
     _description = "lorem ipsum";
@@ -24,6 +24,6 @@ contract StandardAssetRegistryTest is FullAssetRegistry {
 
   // Problematic override on truffle
   function safeTransfer(address from, address to, uint256 assetId, bytes data) public {
-    return _doTransferFrom(from, to, assetId, data, msg.sender, true);
+    return _doTransferFrom(from, to, assetId, data, true);
   }
 }


### PR DESCRIPTION
This PR removes the userData field in the Transfer() event to make it compatible with the standard.