### PR TITLE
fix: update the onERC721Received call to the lastest standard

### DIFF
--- a/contracts/ERC721Base.sol
+++ b/contracts/ERC721Base.sol
@@ -13,6 +13,9 @@ import './ERC165.sol';
 contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
   using SafeMath for uint256;
 
+  // Equals to `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`
+  bytes4 private constant ERC721_RECEIVED = 0x150b7a02;
+
   //
   // Global Getters
   //
@@ -332,11 +335,10 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
     _addAssetTo(to, assetId);
 
     if (doCheck && _isContract(to)) {
-      // Equals to bytes4(keccak256("onERC721Received(address,uint256,bytes)"))
-      bytes4 ERC721_RECEIVED = bytes4(0xf0b9e5ba);
+      // Equals to `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))
       require(
         IERC721Receiver(to).onERC721Received(
-          holder, assetId, userData
+          msg.sender, holder, assetId, userData
         ) == ERC721_RECEIVED
       );
     }

--- a/contracts/ERC721Holder.sol
+++ b/contracts/ERC721Holder.sol
@@ -3,7 +3,13 @@ pragma solidity ^0.4.18;
 import './IERC721Receiver.sol';
 
 contract ERC721Holder is IERC721Receiver {
-  function onERC721Received(address /* oldOwner */, uint256 /* tokenId */, bytes /* data */) external returns (bytes4) {
-    return bytes4(0xf0b9e5ba);
+    /**
+   * @dev Magic value to be returned upon successful reception of an NFT
+   *  Equals to `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`
+   */
+  bytes4 internal constant ERC721_RECEIVED = 0x150b7a02;
+
+  function onERC721Received(address /* _operator */, address /* _from */, uint256 /* _tokenId */, bytes /* _data */) external returns (bytes4) {
+    return ERC721_RECEIVED;
   }
 }

--- a/contracts/IERC721Receiver.sol
+++ b/contracts/IERC721Receiver.sol
@@ -2,7 +2,8 @@ pragma solidity ^0.4.18;
 
 interface IERC721Receiver {
   function onERC721Received(
-    address _oldOwner,
+    address _operator,
+    address _from,
     uint256 _tokenId,
     bytes   _userData
   ) external returns (bytes4);


### PR DESCRIPTION
The implementation was using `onERC721Received(address, uint256, uint256)` while the latest standard supports sending the operator that triggered the callback with the signature `onERC721Received(address, address, uint256, uint256)`