### PR TITLE
fix: support erc721 interface standard

### DIFF
--- a/ERC821.md
+++ b/ERC821.md
@@ -75,7 +75,7 @@ Return the total amount of assets under this DAR. This method SHALL NOT throw.
 
 #### `supportsInterface(bytes8 interfaceId):bool`
 
-This method returns `true` if the `interfaceId` is a supported interface (165, corresponding to 0x01ffc9a7, or 821, corresponding to 0x7c0633c6). This method SHALL NOT throw.
+This method returns `true` if the `interfaceId` is a supported interface (165, corresponding to 0x01ffc9a7, 821, corresponding to 0x7c0633c6, or 721 corresponding to 0x80ac58cd). This method SHALL NOT throw.
 
 ### NFT getter methods
 

--- a/ERC821.md
+++ b/ERC821.md
@@ -41,15 +41,15 @@ The NFT's ID SHOULD have a hint that helps to decode it. For instance, if the en
 
 Some common names for Ethereum blockchains are:
 
-* `ethereum`, `livenet`, or `mainnet`
-* `ropsten`, `testnet`
-* `kovan`
-* `rinkeby`
+- `ethereum`, `livenet`, or `mainnet`
+- `ropsten`, `testnet`
+- `kovan`
+- `rinkeby`
 
 Some examples of NFT URIs follow:
 
-* nft://ethereum/0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d/0
-* nft://ropsten/0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d/0xfaa5be24e996feadf4c96b905af2c77c456e2debd075bab4d8fd5f70f209de44
+- nft://ethereum/0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d/0
+- nft://ropsten/0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d/0xfaa5be24e996feadf4c96b905af2c77c456e2debd075bab4d8fd5f70f209de44
 
 Every NFT MUST have a `owner` address associated with it. NFTs associated with the null address are assumed non-existent or destroyed.
 
@@ -57,9 +57,9 @@ An owner MAY assign one or multiple `operator` addresses. These addresses will b
 
 DARs MUST trigger `Transfer` events every time a NFT's `owner` changes. This might happen under three circumstances:
 
-* A NFT is created. In this case, the `from` value of the `Transfer` event MUST be the zero address.
-* A NFT is transferred to a different owner.
-* A NFT is destroyed. In this case, the `to` value of the `Transfer` event MUST be the zero address.
+- A NFT is created. In this case, the `from` value of the `Transfer` event MUST be the zero address.
+- A NFT is transferred to a different owner.
+- A NFT is destroyed. In this case, the `to` value of the `Transfer` event MUST be the zero address.
 
 `Transfer` events SHALL NOT simultaneously have a zero value in both the `from` and `to` fields (this means, the same `Transfer` event can't both create and destroy a token).
 
@@ -75,7 +75,7 @@ Return the total amount of assets under this DAR. This method SHALL NOT throw.
 
 #### `supportsInterface(bytes8 interfaceId):bool`
 
-This method returns `true` if the `interfaceId` is a supported interface (165, corresponding to 0x01ffc9a7, or 821, corresponding to 0x959d7abb). This method SHALL NOT throw.
+This method returns `true` if the `interfaceId` is a supported interface (165, corresponding to 0x01ffc9a7, or 821, corresponding to 0x7c0633c6). This method SHALL NOT throw.
 
 ### NFT getter methods
 
@@ -145,9 +145,9 @@ If there was any single authorized operator (see the `approve()` method below), 
 
 If the call doesn't throw, it triggers the event `Transfer` with the following parameters:
 
-* from: value of `ownerOf(assetId)` before the call
-* to: the `to` argument
-* assetId: the `assetId` argument
+- from: value of `ownerOf(assetId)` before the call
+- to: the `to` argument
+- assetId: the `assetId` argument
 
 If `to` is a contract's address, this call MUST verify that the contract can receive the tokens. In order to do so, the method MUST do a #165 check for support to handle tokens to the target contract.
 The implementation for the receiver is as follows:
@@ -276,31 +276,31 @@ https://github.com/decentraland/erc821
 
 ## Revisions
 
-* 2018/08/22: Make Transfer() event compliant with the ERC721 reference implementation
-* 2018/02/21: RC2, drop name, symbol, description
-* 2018/02/21: RC1
-* 2018/02/20: Drop metadata
-* 2018/02/20: Add `transferFrom`
-* 2018/02/20: Try to remove `operator` from public facing interfaces
-* 2018/02/20: Simplify `holder` -> `owner` to use the most common name
-* 2018/02/20: Drop all ERC820 references
-* 2018/02/03: Add `approve` to approve individual assets to be transferred
-* 2018/01/27: Add exception for `msg.sender` being the manager
-* 2018/01/27: Add table for `ERC820` and `IAssetHolder` interface check
-* 2018/01/27: Change `IAssetOwner` for `IAssetHolder` to reflect that another contract might hold tokens for one
-* 2018/01/27: Errata on `transfer` text
-* 2018/01/26: Alias "balanceOf" to "assetCount" for ERC20 compatibility
-* 2018/01/26: Add `decimals` for more ERC20 compatibility
-* 2018/01/26: Propose more metadata to be stored on-chain.
-* 2018/01/26: Make EIP820 compatibility optional to receive tokens if `onAssetReceived(...)` is implemented.
-* 2018/01/26: Add `isERC821` flag to detect support.
-* 2018/01/26: Revert `holder` to `owner`.
-* 2018/01/18: `transfer`: `to` MUST NOT be `holderOf(assetId)`
-* 2018/01/17: Added `safeAssetData` method
-* 2018/01/17: Clarification to `transfer`: it MUST throw if the asset does not exist.
-* 2018/01/17: Published first version of the specification
-* 2018/01/16: Published implementation
-* 2018/01/05: Initial draft
+- 2018/08/22: Make Transfer() event compliant with the ERC721 reference implementation
+- 2018/02/21: RC2, drop name, symbol, description
+- 2018/02/21: RC1
+- 2018/02/20: Drop metadata
+- 2018/02/20: Add `transferFrom`
+- 2018/02/20: Try to remove `operator` from public facing interfaces
+- 2018/02/20: Simplify `holder` -> `owner` to use the most common name
+- 2018/02/20: Drop all ERC820 references
+- 2018/02/03: Add `approve` to approve individual assets to be transferred
+- 2018/01/27: Add exception for `msg.sender` being the manager
+- 2018/01/27: Add table for `ERC820` and `IAssetHolder` interface check
+- 2018/01/27: Change `IAssetOwner` for `IAssetHolder` to reflect that another contract might hold tokens for one
+- 2018/01/27: Errata on `transfer` text
+- 2018/01/26: Alias "balanceOf" to "assetCount" for ERC20 compatibility
+- 2018/01/26: Add `decimals` for more ERC20 compatibility
+- 2018/01/26: Propose more metadata to be stored on-chain.
+- 2018/01/26: Make EIP820 compatibility optional to receive tokens if `onAssetReceived(...)` is implemented.
+- 2018/01/26: Add `isERC821` flag to detect support.
+- 2018/01/26: Revert `holder` to `owner`.
+- 2018/01/18: `transfer`: `to` MUST NOT be `holderOf(assetId)`
+- 2018/01/17: Added `safeAssetData` method
+- 2018/01/17: Clarification to `transfer`: it MUST throw if the asset does not exist.
+- 2018/01/17: Published first version of the specification
+- 2018/01/16: Published implementation
+- 2018/01/05: Initial draft
 
 ## Copyright
 

--- a/contracts/ERC721Base.sol
+++ b/contracts/ERC721Base.sol
@@ -16,6 +16,27 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
   // Equals to `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`
   bytes4 private constant ERC721_RECEIVED = 0x150b7a02;
 
+  bytes4 private constant InterfaceId_ERC165 = 0x01ffc9a7;
+  /*
+   * 0x01ffc9a7 ===
+   *   bytes4(keccak256('supportsInterface(bytes4)'))
+   */
+
+  bytes4 private constant Old_InterfaceId_ERC721 = 0x7c0633c6;
+  bytes4 private constant InterfaceId_ERC721 = 0x80ac58cd;
+   /*
+   * 0x80ac58cd ===
+   *   bytes4(keccak256('balanceOf(address)')) ^
+   *   bytes4(keccak256('ownerOf(uint256)')) ^
+   *   bytes4(keccak256('approve(address,uint256)')) ^
+   *   bytes4(keccak256('getApproved(uint256)')) ^
+   *   bytes4(keccak256('setApprovalForAll(address,bool)')) ^
+   *   bytes4(keccak256('isApprovedForAll(address,address)')) ^
+   *   bytes4(keccak256('transferFrom(address,address,uint256)')) ^
+   *   bytes4(keccak256('safeTransferFrom(address,address,uint256)')) ^
+   *   bytes4(keccak256('safeTransferFrom(address,address,uint256,bytes)'))
+   */
+
   //
   // Global Getters
   //
@@ -357,7 +378,7 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
     if (_interfaceID == 0xffffffff) {
       return false;
     }
-    return (_interfaceID == 0x01ffc9a7) || (_interfaceID == 0x7c0633c6);
+    return _interfaceID == InterfaceId_ERC165 || _interfaceID == Old_InterfaceId_ERC721 || _interfaceID == InterfaceId_ERC721;
   }
 
   //


### PR DESCRIPTION
Support [ERC721 standar interface](https://github.com/OpenZeppelin/openzeppelin-zos/blob/master/contracts/token/ERC721/ERC721BasicToken.sol#L16)

Close decentraland/marketplace-contracts#24