### PR TITLE
feat: emit transfer event before calling onERC721Received

### DIFF
--- a/contracts/ERC721Base.sol
+++ b/contracts/ERC721Base.sol
@@ -346,7 +346,7 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
     isDestinataryDefined(to)
     destinataryIsNotHolder(assetId, to)
     isCurrentOwner(from, assetId)
-    internal
+    private
   {
     address holder = _holderOf[assetId];
     _clearApproval(holder, assetId);

--- a/contracts/ERC721Base.sol
+++ b/contracts/ERC721Base.sol
@@ -352,6 +352,7 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
     _clearApproval(holder, assetId);
     _removeAssetFrom(holder, assetId);
     _addAssetTo(to, assetId);
+    emit Transfer(holder, to, assetId);
 
     if (doCheck && _isContract(to)) {
       // Equals to `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))
@@ -361,8 +362,6 @@ contract ERC721Base is AssetRegistryStorage, IERC721Base, ERC165 {
         ) == ERC721_RECEIVED
       );
     }
-
-    emit Transfer(holder, to, assetId);
   }
 
   /**


### PR DESCRIPTION
- Emit transfer event before calling onERC721Received
- Change `_moveToken` visibility from `internal` to `private`