### PR TITLE
feat: fix parameter names

### DIFF
--- a/ERC821.md
+++ b/ERC821.md
@@ -276,6 +276,7 @@ https://github.com/decentraland/erc821
 
 ## Revisions
 
+- 2019/03/07: Fix `ApprovalForAll` parameter names
 - 2018/08/22: Make Transfer() event compliant with the ERC721 reference implementation
 - 2018/02/21: RC2, drop name, symbol, description
 - 2018/02/21: RC1

--- a/contracts/IERC721Base.sol
+++ b/contracts/IERC721Base.sol
@@ -38,8 +38,8 @@ interface IERC721Base {
     uint256 indexed assetId
   );
   event ApprovalForAll(
-    address indexed operator,
     address indexed holder,
+    address indexed operator,
     bool authorized
   );
   event Approval(

--- a/test/StandardAssetRegistry.js
+++ b/test/StandardAssetRegistry.js
@@ -15,9 +15,9 @@ function checkTransferLog(log, assetId, from, to) {
   log.args.to.should.be.equal(to)
 }
 
-function checkAuthorizationLog(log, operator, holder, authorized) {
+function checkAuthorizationLog(log, holder, operator, authorized) {
   log.event.should.be.eq('ApprovalForAll')
-  log.args.operator.should.be.bignumber.equal(operator)
+  log.args.operator.should.be.equal(operator)
   log.args.holder.should.be.equal(holder)
   log.args.authorized.should.be.equal(authorized)
 }


### PR DESCRIPTION
We were emitting the `ApprovalForAll` event as:

`emit ApprovalForAll(msg.sender, operator, authorized);` 

But the event definition was: 

```javascript
 event ApprovalForAll(
    address indexed operator,
    address indexed holder,
    bool authorized
  );
```

This PR change the order of the event parameter names to: 

```javascript
 event ApprovalForAll(
    address indexed holder,
    address indexed operator,
    bool authorized
  );
```
